### PR TITLE
js-templates.class-export 1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
-# js-templates.class-export [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/js-templates.class-export.svg)](https://www.npmjs.com/package/js-templates.class-export) [![Downloads](https://img.shields.io/npm/dt/js-templates.class-export.svg)](https://www.npmjs.com/package/js-templates.class-export) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# js-templates.class-export
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/js-templates.class-export.svg)](https://www.npmjs.com/package/js-templates.class-export) [![Downloads](https://img.shields.io/npm/dt/js-templates.class-export.svg)](https://www.npmjs.com/package/js-templates.class-export) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Generate a sample class export code.
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "export"
   ],
   "license": "MIT",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "lib/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -33,6 +33,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
 - Updated the README.md following the new template. :memo:
 - Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.